### PR TITLE
Made withdraw an interface function

### DIFF
--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -139,7 +139,7 @@ contract TokenVesting is Ownable, IVesting {
     * @notice Withdraws TCR tokens from the contract.
     * @dev blocks withdrawing locked tokens.
     */
-    function withdraw(uint amount) public onlyOwner {
+    function withdraw(uint amount) public override onlyOwner {
         require(
             TCR.balanceOf(address(this)).sub(valueLocked) >= amount,
             "Vesting: amount > tokens leftover"

--- a/contracts/interfaces/IVesting.sol
+++ b/contracts/interfaces/IVesting.sol
@@ -53,4 +53,10 @@ interface IVesting {
         uint256 startTime,
         uint256 endTime
     ) external pure returns (uint256);
+
+    /**
+    * @notice Withdraws TCR tokens from the contract.
+    * @dev blocks withdrawing locked tokens.
+    */
+    function withdraw(uint amount) external;
 }


### PR DESCRIPTION
### Motivation
`withdraw` needs to be a function in the IVesting interface, to allow for VestingAirdrop contract to interact with it via IVesting

### Changes
makes `withdraw` in Vesting.sol an interface function