### PR TITLE
Employee vesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 package-lock.json
+yarn.lock
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 package-lock.json
 yarn.lock
 build/
+.openzeppelin

--- a/contracts/vesting/EmployeeVesting.sol
+++ b/contracts/vesting/EmployeeVesting.sol
@@ -22,30 +22,30 @@ contract EmployeeVesting is Ownable, IVesting {
         bool cliffClaimed;
     }
 
-    mapping (address => mapping(uint => Schedule)) public schedules;
-    mapping (address => uint) public numberOfSchedules;
+    mapping(address => mapping(uint256 => Schedule)) public schedules;
+    mapping(address => uint256) public numberOfSchedules;
 
     uint256 public valueLocked;
     IERC20 private TCR;
     address public DAO;
 
-    event Claim(uint amount, address claimer);
+    event Claim(uint256 amount, address claimer);
 
-    // take in the DAO address
-    constructor(address tcr) public {
+    constructor(address tcr, address dao) public {
         TCR = IERC20(tcr);
+        DAO = dao;
     }
 
     /**
-    * @notice Sets up a vesting schedule for a set user.
-    * @dev adds a new Schedule to the schedules mapping.
-    * @param account the account that a vesting schedule is being set up for. Will be able to claim tokens after
-    *                the cliff period.
-    * @param amount the amount of tokens being vested for the user.
-    * @param isFixed a flag for if the vesting schedule is fixed or not. Fixed vesting schedules can't be cancelled.
-    * @param cliffWeeks the number of weeks that the cliff will be present at.
-    * @param vestingWeeks the number of weeks the tokens will vest over (linearly)
-    */
+     * @notice Sets up a vesting schedule for a set user.
+     * @dev adds a new Schedule to the schedules mapping.
+     * @param account the account that a vesting schedule is being set up for. Will be able to claim tokens after
+     *                the cliff period.
+     * @param amount the amount of tokens being vested for the user.
+     * @param isFixed a flag for if the vesting schedule is fixed or not. Fixed vesting schedules can't be cancelled.
+     * @param cliffWeeks the number of weeks that the cliff will be present at.
+     * @param vestingWeeks the number of weeks the tokens will vest over (linearly)
+     */
     function setVestingSchedule(
         address account,
         uint256 amount,
@@ -53,7 +53,6 @@ contract EmployeeVesting is Ownable, IVesting {
         uint256 cliffWeeks,
         uint256 vestingWeeks
     ) public override onlyOwner {
-        // remove requirement for tokens to be present
         require(
             vestingWeeks >= cliffWeeks,
             "Vesting: cliff after vesting period"
@@ -71,34 +70,39 @@ contract EmployeeVesting is Ownable, IVesting {
         numberOfSchedules[account] = currentNumSchedules + 1;
         valueLocked = valueLocked.add(amount);
     }
-    // create a setVestingSchedules function
-    // allows setting many schedules with one txn 
-     /**
-    * @notice Sets up vesting schedules for multiple users within 1 transaction.
-    * @dev adds a new Schedule to the schedules mapping.
-    * @param accounts an array of the accounts that the vesting schedules are being set up for.
-    *                 Will be able to claim tokens after the cliff period.               
-    * @param amount an array of the amount of tokens being vested for each user.
-    * @param isFixed an array of flags for if each users vesting schedule is fixed or not. Fixed vesting schedules can't be cancelled.
-    * @param cliffWeeks an array of the number of weeks that the users cliff will be present at.
-    * @param vestingWeeks an array of the number of weeks the each users tokens will vest over (linearly)
-    */
+
+    /**
+     * @notice Sets up vesting schedules for multiple users within 1 transaction.
+     * @dev adds a new Schedule to the schedules mapping.
+     * @param accounts an array of the accounts that the vesting schedules are being set up for.
+     *                 Will be able to claim tokens after the cliff period.
+     * @param amount an array of the amount of tokens being vested for each user.
+     * @param isFixed an array of flags for if each users vesting schedule is fixed or not. Fixed vesting schedules can't be cancelled.
+     * @param cliffWeeks an array of the number of weeks that the users cliff will be present at.
+     * @param vestingWeeks an array of the number of weeks the each users tokens will vest over (linearly)
+     */
     function setVestingSchedules(
         address[] calldata accounts,
-        uint[] calldata amount,
+        uint256[] calldata amount,
         bool[] calldata isFixed,
-        uint[] calldata cliffWeeks,
-        uint[] calldata vestingWeeks
-    ) public onlyOwner{
+        uint256[] calldata cliffWeeks,
+        uint256[] calldata vestingWeeks
+    ) public onlyOwner {
         uint256 numberOfAccounts = accounts.length;
-        for(uint256 i=0; i<numberOfAccounts; i++){
-            setVestingSchedule(accounts[i], amount[i], isFixed[i], cliffWeeks[i], vestingWeeks[i]);
+        for (uint256 i = 0; i < numberOfAccounts; i++) {
+            setVestingSchedule(
+                accounts[i],
+                amount[i],
+                isFixed[i],
+                cliffWeeks[i],
+                vestingWeeks[i]
+            );
         }
     }
 
     /**
-    * @notice allows users to claim vested tokens if the cliff time has passed.
-    */
+     * @notice allows users to claim vested tokens if the cliff time has passed.
+     */
     function claim(uint256 scheduleNumber) public override {
         Schedule storage schedule = schedules[msg.sender][scheduleNumber];
         require(
@@ -108,39 +112,52 @@ contract EmployeeVesting is Ownable, IVesting {
         require(schedule.totalAmount > 0, "Vesting: No claimable tokens");
 
         // Get the amount to be distributed
-        uint amount = calcDistribution(schedule.totalAmount, block.timestamp, schedule.startTime, schedule.endTime);
-        
+        uint256 amount =
+            calcDistribution(
+                schedule.totalAmount,
+                block.timestamp,
+                schedule.startTime,
+                schedule.endTime
+            );
+
         // Cap the amount at the total amount
         amount = amount > schedule.totalAmount ? schedule.totalAmount : amount;
-        uint amountToTransfer = amount.sub(schedule.claimedAmount);
+        uint256 amountToTransfer = amount.sub(schedule.claimedAmount);
         schedule.claimedAmount = amount; // set new claimed amount based off the curve
         TCR.safeTransfer(msg.sender, amountToTransfer);
         emit Claim(amount, msg.sender);
     }
 
     /**
-    * @notice Allows a vesting schedule to be cancelled.
-    * @dev Any outstanding tokens are returned to the system.
-    * @param account the account of the user whos vesting schedule is being cancelled.
-    */
-    // @todo make vesting cancellable only by DAO
-    function cancelVesting(address account, uint256 scheduleId) public override onlyDAO {
+     * @notice Allows a vesting schedule to be cancelled.
+     * @dev Any outstanding tokens are returned to the system.
+     * @param account the account of the user whos vesting schedule is being cancelled.
+     */
+    function cancelVesting(address account, uint256 scheduleId)
+        public
+        override
+        onlyDAO
+    {
         Schedule storage schedule = schedules[account][scheduleId];
-        require(schedule.claimedAmount < schedule.totalAmount, "Vesting: Tokens fully claimed");
+        require(
+            schedule.claimedAmount < schedule.totalAmount,
+            "Vesting: Tokens fully claimed"
+        );
         require(!schedule.isFixed, "Vesting: Account is fixed");
-        uint256 outstandingAmount = schedule.totalAmount.sub(schedule.claimedAmount);
+        uint256 outstandingAmount =
+            schedule.totalAmount.sub(schedule.claimedAmount);
         schedule.totalAmount = 0;
         valueLocked = valueLocked.sub(outstandingAmount);
     }
 
     /**
-    * @notice returns the total amount and total claimed amount of a users vesting schedule.
-    * @param account the user to retrieve the vesting schedule for.
-    */
+     * @notice returns the total amount and total claimed amount of a users vesting schedule.
+     * @param account the user to retrieve the vesting schedule for.
+     */
     function getVesting(address account, uint256 scheduleId)
         public
-        override
         view
+        override
         returns (uint256, uint256)
     {
         Schedule memory schedule = schedules[account][scheduleId];
@@ -148,22 +165,28 @@ contract EmployeeVesting is Ownable, IVesting {
     }
 
     /**
-    * @notice calculates the amount of tokens to distribute to an account at any instance in time, based off some
-    *         total claimable amount.
-    * @param amount the total outstanding amount to be claimed for this vesting schedule.
-    * @param currentTime the current timestamp.
-    * @param startTime the timestamp this vesting schedule started.
-    * @param endTime the timestamp this vesting schedule ends.
-    */
-    function calcDistribution(uint amount, uint currentTime, uint startTime, uint endTime) public override pure returns(uint256) {
-        return amount.mul(currentTime.sub(startTime)).div(endTime.sub(startTime));
+     * @notice calculates the amount of tokens to distribute to an account at any instance in time, based off some
+     *         total claimable amount.
+     * @param amount the total outstanding amount to be claimed for this vesting schedule.
+     * @param currentTime the current timestamp.
+     * @param startTime the timestamp this vesting schedule started.
+     * @param endTime the timestamp this vesting schedule ends.
+     */
+    function calcDistribution(
+        uint256 amount,
+        uint256 currentTime,
+        uint256 startTime,
+        uint256 endTime
+    ) public pure override returns (uint256) {
+        return
+            amount.mul(currentTime.sub(startTime)).div(endTime.sub(startTime));
     }
 
     /**
-    * @notice Withdraws TCR tokens from the contract.
-    * @dev blocks withdrawing locked tokens.
-    */
-    function withdraw(uint amount) public override onlyOwner {
+     * @notice Withdraws TCR tokens from the contract.
+     * @dev blocks withdrawing locked tokens.
+     */
+    function withdraw(uint256 amount) public override onlyOwner {
         require(
             TCR.balanceOf(address(this)).sub(valueLocked) >= amount,
             "Vesting: amount > tokens leftover"
@@ -171,12 +194,15 @@ contract EmployeeVesting is Ownable, IVesting {
         TCR.safeTransfer(owner(), amount);
     }
 
-    // create an only DAO modifier
-    modifier onlyDAO() {
-        require(msg.sender == address(DAO));
-        _;
-    }
-    function setDAOAddress(address DAOAddress) public onlyOwner{
+    /**
+     * @notice sets the address of the Tracer DAO.
+     */
+    function setDAOAddress(address DAOAddress) public onlyOwner {
         DAO = DAOAddress;
+    }
+
+    modifier onlyDAO() {
+        require(msg.sender == address(DAO), "Vesting: Caller not DAO");
+        _;
     }
 }

--- a/contracts/vesting/EmployeeVesting.sol
+++ b/contracts/vesting/EmployeeVesting.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/math/SignedSafeMath.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interfaces/IVesting.sol";
+
+contract EmployeeVesting is Ownable, IVesting {
+    using SafeERC20 for IERC20;
+    using SafeMath for uint256;
+
+    struct Schedule {
+        uint256 totalAmount;
+        uint256 claimedAmount;
+        uint256 startTime;
+        uint256 cliffTime;
+        uint256 endTime;
+        bool isFixed;
+        bool cliffClaimed;
+    }
+
+    mapping (address => mapping(uint => Schedule)) public schedules;
+    mapping (address => uint) public numberOfSchedules;
+
+    uint256 public valueLocked;
+    IERC20 private TCR;
+
+    event Claim(uint amount, address claimer);
+
+    // take in the DAO address
+    constructor(address tcr) public {
+        TCR = IERC20(tcr);
+    }
+
+    // create a setVestingSchedules function
+    // allows setting many schedules with one txn
+
+    /**
+    * @notice Sets up a vesting schedule for a set user.
+    * @dev adds a new Schedule to the schedules mapping.
+    * @param account the account that a vesting schedule is being set up for. Will be able to claim tokens after
+    *                the cliff period.
+    * @param amount the amount of tokens being vested for the user.
+    * @param isFixed a flag for if the vesting schedule is fixed or not. Fixed vesting schedules can't be cancelled.
+    * @param cliffWeeks the number of weeks that the cliff will be present at.
+    * @param vestingWeeks the number of weeks the tokens will vest over (linearly)
+    */
+    function setVestingSchedule(
+        address account,
+        uint256 amount,
+        bool isFixed,
+        uint256 cliffWeeks,
+        uint256 vestingWeeks
+    ) public override onlyOwner {
+        // remove requirement for tokens to be present
+        require(
+            TCR.balanceOf(address(this)).sub(valueLocked) >= amount,
+            "Vesting: amount > tokens leftover"
+        );
+        require(
+            vestingWeeks >= cliffWeeks,
+            "Vesting: cliff after vesting period"
+        );
+        uint256 currentNumSchedules = numberOfSchedules[account];
+        schedules[account][currentNumSchedules] = Schedule(
+            amount,
+            0,
+            block.timestamp,
+            block.timestamp.add(cliffWeeks * 1 weeks),
+            block.timestamp.add(vestingWeeks * 1 weeks),
+            isFixed,
+            false
+        );
+        numberOfSchedules[account] = currentNumSchedules + 1;
+        valueLocked = valueLocked.add(amount);
+    }
+
+    /**
+    * @notice allows users to claim vested tokens if the cliff time has passed.
+    */
+    function claim(uint256 scheduleNumber) public override {
+        Schedule storage schedule = schedules[msg.sender][scheduleNumber];
+        require(
+            schedule.cliffTime <= block.timestamp,
+            "Vesting: cliffTime not reached"
+        );
+        require(schedule.totalAmount > 0, "Vesting: No claimable tokens");
+
+        // Get the amount to be distributed
+        uint amount = calcDistribution(schedule.totalAmount, block.timestamp, schedule.startTime, schedule.endTime);
+        
+        // Cap the amount at the total amount
+        amount = amount > schedule.totalAmount ? schedule.totalAmount : amount;
+        uint amountToTransfer = amount.sub(schedule.claimedAmount);
+        schedule.claimedAmount = amount; // set new claimed amount based off the curve
+        TCR.safeTransfer(msg.sender, amountToTransfer);
+        emit Claim(amount, msg.sender);
+    }
+
+    /**
+    * @notice Allows a vesting schedule to be cancelled.
+    * @dev Any outstanding tokens are returned to the system.
+    * @param account the account of the user whos vesting schedule is being cancelled.
+    */
+    // @todo make vesting cancellable only by DAO
+    function cancelVesting(address account, uint256 scheduleId) public override onlyOwner {
+        Schedule storage schedule = schedules[account][scheduleId];
+        require(schedule.claimedAmount < schedule.totalAmount, "Vesting: Tokens fully claimed");
+        require(!schedule.isFixed, "Vesting: Account is fixed");
+        uint256 outstandingAmount = schedule.totalAmount.sub(schedule.claimedAmount);
+        schedule.totalAmount = 0;
+        valueLocked = valueLocked.sub(outstandingAmount);
+    }
+
+    /**
+    * @notice returns the total amount and total claimed amount of a users vesting schedule.
+    * @param account the user to retrieve the vesting schedule for.
+    */
+    function getVesting(address account, uint256 scheduleId)
+        public
+        override
+        view
+        returns (uint256, uint256)
+    {
+        Schedule memory schedule = schedules[account][scheduleId];
+        return (schedule.totalAmount, schedule.claimedAmount);
+    }
+
+    /**
+    * @notice calculates the amount of tokens to distribute to an account at any instance in time, based off some
+    *         total claimable amount.
+    * @param amount the total outstanding amount to be claimed for this vesting schedule.
+    * @param currentTime the current timestamp.
+    * @param startTime the timestamp this vesting schedule started.
+    * @param endTime the timestamp this vesting schedule ends.
+    */
+    function calcDistribution(uint amount, uint currentTime, uint startTime, uint endTime) public override pure returns(uint256) {
+        return amount.mul(currentTime.sub(startTime)).div(endTime.sub(startTime));
+    }
+
+    /**
+    * @notice Withdraws TCR tokens from the contract.
+    * @dev blocks withdrawing locked tokens.
+    */
+    function withdraw(uint amount) public override onlyOwner {
+        require(
+            TCR.balanceOf(address(this)).sub(valueLocked) >= amount,
+            "Vesting: amount > tokens leftover"
+        );
+        TCR.safeTransfer(owner(), amount);
+    }
+
+    // create an only DAO modifier
+
+}

--- a/contracts/vesting/EmployeeVesting.sol
+++ b/contracts/vesting/EmployeeVesting.sol
@@ -142,6 +142,7 @@ contract EmployeeVesting is Ownable {
         amount = amount > schedule.totalAmount ? schedule.totalAmount : amount;
         uint256 amountToTransfer = amount.sub(schedule.claimedAmount);
         schedule.claimedAmount = amount; // set new claimed amount based off the curve
+        valueLocked = valueLocked.sub(amountToTransfer);
         TCR.safeTransfer(msg.sender, amountToTransfer);
         emit Claim(amount, msg.sender);
     }

--- a/contracts/vesting/Vesting.sol
+++ b/contracts/vesting/Vesting.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "./interfaces/IVesting.sol";
+import "../interfaces/IVesting.sol";
 
 contract TokenVesting is Ownable, IVesting {
     using SafeERC20 for IERC20;

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -111,6 +111,19 @@ module.exports = async function(deployer, network, accounts) {
         console.log("Transferring remaining tokens to DAO")
         await tcr.transfer(proxy.address, web3.utils.toWei('980000000'))
 
+        const withdrawData = web3.eth.abi.encodeFunctionCall(
+            {
+                name: "withdrawFromVesting",
+                type: "function",
+                inputs: [
+                    { type: "uint256", name: "amount" },
+                ],
+            },
+            ["2599948000000000000000000"]
+        )
+        
+        console.log(withdrawData)
+
     } else {
         // Send 99% of tokens to gov contract
         // 99% of 1 billion = 990 million

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -3,9 +3,46 @@ const { ether } = require("@openzeppelin/test-helpers")
 const DAOUpgradable = artifacts.require("TracerDAO")
 const TCR = artifacts.require("TracerToken");
 const Vesting = artifacts.require("TokenVesting")
+const EmployeeVesting = artifacts.require("EmployeeVesting")
 const Claim = artifacts.require("InitialClaim")
 const SelfUpgradableProxy = artifacts.require("CustomUpgradeableProxy")
 module.exports = async function(deployer, network, accounts) {
+
+    if (network == "EmployeeVesting") {
+        let tracerToken = "0x9C4A4204B79dd291D6b6571C5BE8BbcD0622F050"
+        let daoAddress = "0xA84918F3280d488EB3369Cb713Ec53cE386b6cBa"
+        let lionsmaneMultisig = "0xa6a006c12338cdcdbc882c6ab97e4f9f82340651"
+        await deployer.deploy(EmployeeVesting, tracerToken, daoAddress)
+        let employeeVesting = await EmployeeVesting.deployed()
+
+        //set vesting for current employees
+        let employeeAddresses = []
+        let amounts = []
+        let isFixed = []
+        let cliffWeeks = []
+        let vestingWeeks = []
+
+        for (var i = 0; i < employeeAddresses; i++) {
+            isFixed.push(false)
+            cliffWeeks.push(0)
+            vestingWeeks.push(156)
+        }
+
+        await employeeVesting.setVestingSchedules(
+            employeeAddresses,
+            amounts,
+            isFixed,
+            cliffWeeks,
+            vestingWeeks
+        )
+
+        //transfer ownership to the Lionsmane multisig for all future
+        //employees to have vesting set
+        await employeeVesting.transferOwnership(lionsmaneMultisig)
+        console.log(employeeVesting.address)
+        return
+    }
+
     const day = 86400
 
     // Deploy TCR token -> total supply of 1 billion tokens

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -14,18 +14,81 @@ module.exports = async function(deployer, network, accounts) {
         let lionsmaneMultisig = "0xa6a006c12338cdcdbc882c6ab97e4f9f82340651"
         await deployer.deploy(EmployeeVesting, tracerToken, daoAddress)
         let employeeVesting = await EmployeeVesting.deployed()
-
+        let febTwelve = 1613052000 // unix secs on feb 12th
         //set vesting for current employees
-        let employeeAddresses = []
-        let amounts = []
+        let employeeAddresses = [
+            "0x44fF73eC0Cb47b74C6ebd6d62B71E946f312f5e4",
+            "0x2f99b7C0BDCD933f58D49a4A6a172b1a03cbb413",
+            "0x3e94F8549d71D98Ee7C7927dBb0150B35b7bdeee",
+            "0x7d25f611DCDc45838DC1A2A0F7321ef8CB8C20bA",
+            "0x84Be8f20279d9c403e055853BF5531D003E3A542",
+            "0xcB46CA9b99988c1F7160E45C661484038b632680",
+            "0x64C83eC49450747024451ac3bcCdBC2c2f2C6BC4",
+            "0x3E96CAafE1bD5Dc781606c5974F6C885613fEd21",
+            "0xb0008569B1899C9f405d27A0B3cEd2B83106CE87",
+            "0x03FE32FD47133C8CBb5738115481272E1dBceb73",
+            "0x4cb916632bFF19dC8dD6884d665284820eb7C389",
+            "0xCcc9f6E37D07AE853Fa2b9997614F9dBC4575376",
+            "0x5E9F986942F7Abb41Ae5D0DE697DDf6E9F302818",
+            "0x49391Ef29F9512D366ef9E8687730f621B8743d1",
+            "0xc7307Fd7fc10Bd5DA7Abb99172b64B040d89FdEa",
+            "0x30c648196541159bdd77Dd35E0b203bC4B6e7822",
+            "0x621e4B4656fF6905E1F8d35B39a520DA671cdE4F",
+            "0x4c82c51a96eA9e951D1b5e8CedC53b980Ec9D3B1",
+            "0x69d64f3a728AA44120d19D6e8e10b837Bdf8cA69",
+            "0xA571b83275fc41B6287d33ab16a905A07232575A",
+            "0x157595f04C0da495D72CEb84390f444D469c3216",
+            "0xBc7652a89f374AFDaB681F461B5be76aA1BA6446",
+            "0xBf6A5f598a4F4B733B85f18fFA284d94a57B6244",
+            "0xa8E3B87D1109fF909c867A319316987412e59F50",
+            "0x87887d8ac550579dA751C671ca83fB8c2a22B90d",
+            "0xb94AcE19eCD7CE5cc36d16d5112A51E76A33EB7D",
+            "0x5EC90BE09d231fbDFd92aD51949a1198c864Ac73",
+            "0x020f94A8b494BE778E409cddCBdA1b10ed01DE9a",
+            "0xC32c7Af3FA81206Dcd83ac0e46AF05D699405c14",
+            "0xF08Fc2f299a7c559EFBe4bD8a8bf22E436e6c092"
+        ]
+        let amounts = [
+            web3.utils.toWei("1500000"),
+            web3.utils.toWei("4000000"),
+            web3.utils.toWei("1750000"),
+            web3.utils.toWei("5000000"),
+            web3.utils.toWei("2500000"),
+            web3.utils.toWei("2500000"),
+            web3.utils.toWei("2500000"),
+            web3.utils.toWei("1000000"),
+            web3.utils.toWei("250000"),
+            web3.utils.toWei("5000000"),
+            web3.utils.toWei("300000"),
+            web3.utils.toWei("2250000"),
+            web3.utils.toWei("2500000"),
+            web3.utils.toWei("3000000"),
+            web3.utils.toWei("5000000"),
+            web3.utils.toWei("650000"),
+            web3.utils.toWei("75000"),
+            web3.utils.toWei("400000"),
+            web3.utils.toWei("5000000"),
+            web3.utils.toWei("10000000"),
+            web3.utils.toWei("10000000"),
+            web3.utils.toWei("100000"),
+            web3.utils.toWei("250000"),
+            web3.utils.toWei("500000"),
+            web3.utils.toWei("500000"),
+            web3.utils.toWei("500000"),
+            web3.utils.toWei("100000"),
+            web3.utils.toWei("400000"),
+            web3.utils.toWei("1000000"),
+            web3.utils.toWei("1000000")
+        ]
         let isFixed = []
         let cliffWeeks = []
         let vestingWeeks = []
-
+        let startTimes = []
         for (var i = 0; i < employeeAddresses; i++) {
             isFixed.push(false)
             cliffWeeks.push(0)
             vestingWeeks.push(156)
+            startTimes.push(febTwelve)
         }
 
         await employeeVesting.setVestingSchedules(
@@ -33,13 +96,13 @@ module.exports = async function(deployer, network, accounts) {
             amounts,
             isFixed,
             cliffWeeks,
-            vestingWeeks
+            vestingWeeks,
+            startTimes
         )
 
         //transfer ownership to the Lionsmane multisig for all future
         //employees to have vesting set
         await employeeVesting.transferOwnership(lionsmaneMultisig)
-        console.log(employeeVesting.address)
         return
     }
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -84,7 +84,7 @@ module.exports = async function(deployer, network, accounts) {
         let cliffWeeks = []
         let vestingWeeks = []
         let startTimes = []
-        for (var i = 0; i < employeeAddresses; i++) {
+        for (var i = 0; i < employeeAddresses.length; i++) {
             isFixed.push(false)
             cliffWeeks.push(0)
             vestingWeeks.push(156)

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
         "test": "test"
     },
     "dependencies": {
-        "@openzeppelin/contracts": "^3.3.0",
-        "@openzeppelin/contracts-upgradeable": "^3.2.0",
+        "@openzeppelin/contracts": "3.3.0",
+        "@openzeppelin/contracts-upgradeable": "^4.0.0",
+        "@openzeppelin/test-helpers": "^0.5.10",
+        "@openzeppelin/truffle-upgrades": "^1.5.0",
         "@truffle/hdwallet-provider": "^1.2.1",
         "web3": "^1.3.0"
     },
     "devDependencies": {
-        "@openzeppelin/test-helpers": "^0.5.9",
-        "@openzeppelin/truffle-upgrades": "^1.5.0",
         "@poanet/solidity-flattener": "^3.0.6",
         "truffle-flattener": "^1.5.0",
         "truffle-plugin-verify": "^0.5.4"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "truffle-plugin-verify": "^0.5.4"
     },
     "scripts": {
-	"migrate:local": "truffle migrate --network=development" ,
+        "migrate:local": "truffle migrate --network=development",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "author": "",

--- a/test/EmployeeVesting.js
+++ b/test/EmployeeVesting.js
@@ -1,0 +1,365 @@
+const DAO = artifacts.require("TracerDAO");
+const TCR = artifacts.require("TracerToken");
+const EmployeeVesting = artifacts.require("TokenVesting")
+const { BN, expectRevert, time } = require('@openzeppelin/test-helpers');
+const { web3 } = require('@openzeppelin/test-helpers/src/setup');
+const { assert } = require('chai');
+
+contract('EmployeeVesting', (accounts) => {
+    const oneDollar = new BN('1000000')
+    const threeDays = 259200
+    const twoDays = 172800
+
+    let tcr, vesting
+    beforeEach(async () => {
+        tcr = await TCR.new(web3.utils.toWei('10000'), accounts[0])
+        vesting = await EmployeeVesting.new(tcr.address)
+        await tcr.transfer(vesting.address, web3.utils.toWei('5000'))
+    })
+
+    describe('setVesting', () => {
+        context('When not the owner', () => {
+            it('fails', async () => {
+                await expectRevert(
+                    vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156, { from: accounts[1] }),
+                    'Ownable: caller is not the owner'
+                )
+            })
+        })
+
+        context('When not enough tokens are held', () => {
+            it('fails', async () => {
+                await expectRevert(
+                    vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50000000'), true, 26, 156),
+                    `Vesting: amount > tokens leftover`
+                )
+            })
+        })
+
+        context('When called by the owner with tokens', () => {
+            it('Can set a vesting schedule', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+                let userVesting = await vesting.getVesting(accounts[1], 0)
+                assert.equal(userVesting[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(userVesting[1].toString(), await web3.utils.toWei('0'))
+            })
+
+            it('Can set multiple vesting schedules per user', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+                let userVesting = await vesting.getVesting(accounts[1], 0)
+                assert.equal(userVesting[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(userVesting[1].toString(), await web3.utils.toWei('0'))
+
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('75'), true, 26, 156);
+                let userVesting2 = await vesting.getVesting(accounts[1], 1)
+                assert.equal(userVesting2[0].toString(), await web3.utils.toWei('75'))
+                assert.equal(userVesting2[1].toString(), await web3.utils.toWei('0'))
+            })
+        })
+    })
+
+    describe('claim', () => {
+        context('When not vesting', () => {
+            it('fails', async () => {
+                await expectRevert(
+                    vesting.claim(0, { from: accounts[1] }),
+                    `Vesting: No claimable tokens`
+                )
+            })
+        })
+
+        context('When cliff has not been reached', () => {
+            it('fails', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+                await expectRevert(
+                    vesting.claim(0,{ from: accounts[1] }),
+                    'Vesting: cliffTime not reached'
+                )
+            })
+        })
+
+        context('When a user has no tokens to claim (amount = 0)', () => {
+            it('fails', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('0'), true, 26, 156);
+                time.increase(26 * 7 * 24 * 60 * 60)
+                await expectRevert(
+                    vesting.claim(0, { from: accounts[1] }),
+                    'Vesting: No claimable tokens'
+                )
+            })
+        })
+        context('When the owner create multiple vesting schedules', () => {
+            it('succeeds', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('150'))
+                await vesting.setVestingSchedules([accounts[1], accounts[2], accounts[3]], [web3.utils.toWei('50'), web3.utils.toWei('50'), web3.utils.toWei('50')] , [true, true, true] , [26, 26, 26], [156, 156, 156]);
+                let balance1 = await tcr.balanceOf(accounts[1])
+                let balance2 = await tcr.balanceOf(accounts[2])
+                let balance3 = await tcr.balanceOf(accounts[3])
+                time.increase(26 * 7 * 24 * 60 * 60)
+                vesting.claim(0, { from: accounts[1] }),
+                vesting.claim(0, { from: accounts[2] }),
+                vesting.claim(0, { from: accounts[3] }),
+                balance1 = await tcr.balanceOf(accounts[1])
+                balance2 = await tcr.balanceOf(accounts[2])
+                balance3 = await tcr.balanceOf(accounts[3])
+            })
+        })
+
+        context('When a user has correctly vested', () => {
+            it('Distributes their tokens', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+                let userVesting = await vesting.getVesting(accounts[1], 0)
+                assert.equal(userVesting[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(userVesting[1].toString(), await web3.utils.toWei('0'))
+
+                time.increase(39 * 7 * 24 * 60 * 60)
+                await vesting.claim(0, { from: accounts[1] })
+                let claimed = await vesting.getVesting(accounts[1], 0)
+                assert.equal(claimed[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(claimed[1].toString().slice(0, 4), await web3.utils.toWei('12.5').toString().slice(0, 4))
+            })
+
+
+            it('Factors in the already claimed amount', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+
+                let balance1 = await tcr.balanceOf(accounts[1])
+                time.increase(39 * 7 * 24 * 60 * 60)
+                await vesting.claim(0, { from: accounts[1] })
+                let claimed = await vesting.getVesting(accounts[1], 0)
+                let balance2 = await tcr.balanceOf(accounts[1])
+                assert.equal(claimed[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(claimed[1].toString().slice(0, 4), await web3.utils.toWei('12.5').toString().slice(0, 4))
+                assert.equal(balance2.sub(balance1).toString().slice(0, 4), web3.utils.toWei('12.5').toString().slice(0, 4))
+
+                // Increase to 78 weeks = 26 + 26
+                time.increase(39 * 7 * 24 * 60 * 60)
+                let balance3 = await tcr.balanceOf(accounts[1])
+                await vesting.claim(0, { from: accounts[1] })
+                let claimed2 = await vesting.getVesting(accounts[1], 0)
+                let balance4 = await tcr.balanceOf(accounts[1])
+                assert.equal(balance4.sub(balance3).toString().slice(0, 4), web3.utils.toWei('12.5').toString().slice(0, 4))
+                assert.equal(claimed2[0].toString().slice(0, 4), await web3.utils.toWei('50').toString().slice(0, 4))
+                assert.equal(claimed2[1].toString().slice(0, 4), await web3.utils.toWei('25').toString().slice(0, 4))
+            })
+
+
+            it('Is linear over 3 years', async () => {
+                let startTime = 0
+                let endTime = 156 * 7 * 24 * 60 * 60 //3 years in secs
+
+                // 25% after 39 weeks 
+                var currentTime = 39 * 7 * 24 * 60 * 60
+                let curve1 = await vesting.calcDistribution(web3.utils.toWei('50'), currentTime, startTime, endTime)
+                assert.equal(curve1.toString(), await web3.utils.toWei('12.5'))
+
+                // 75% after 117 weeks
+                var currentTime = 117 * 7 * 24 * 60 * 60
+                let curve2 = await vesting.calcDistribution(web3.utils.toWei('50'), currentTime, startTime, endTime)
+                assert.equal(curve2.toString(), await web3.utils.toWei('37.5'))
+
+                // 100% after 156 weeks
+                var currentTime = 156 * 7 * 24 * 60 * 60
+                let curve3 = await vesting.calcDistribution(web3.utils.toWei('50'), currentTime, startTime, endTime)
+                assert.equal(curve3.toString(), await web3.utils.toWei('50'))
+
+            })
+
+            it('Doesnt let a user claim any more tokens once all are claimed', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+
+                //Increase to 2 years and claim all
+                time.increase(156 * 7 * 24 * 60 * 60)
+                let balanceBefore = await tcr.balanceOf(accounts[1])
+                await vesting.claim(0, { from: accounts[1] })
+                let balanceAfter = await tcr.balanceOf(accounts[1])
+                assert.equal(balanceAfter.sub(balanceBefore).toString(), web3.utils.toWei('50'))
+
+                //Increase another 6 months
+                time.increase(26 * 7 * 24 * 60 * 60)
+                let balanceBefore2 = await tcr.balanceOf(accounts[1])
+                await vesting.claim(0,{ from: accounts[1] })
+                let balanceAfter2 = await tcr.balanceOf(accounts[1])
+                assert.equal(balanceAfter2.sub(balanceBefore2).toString(), web3.utils.toWei('0'))
+            })
+
+            it('Lets a user claim all your tokens after 3 years have passed', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+
+                //Increase to 3+ years and claim all
+                time.increase(160 * 7 * 24 * 60 * 60)
+                let balanceBefore = await tcr.balanceOf(accounts[1])
+                await vesting.claim(0, { from: accounts[1] })
+                let balanceAfter = await tcr.balanceOf(accounts[1])
+                assert.equal(balanceAfter.sub(balanceBefore).toString(), web3.utils.toWei('50'))
+            })
+
+            it('Allows a user to claim all tokens when cliff = total duration', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 26);
+                let userVesting = await vesting.getVesting(accounts[1], 0)
+                assert.equal(userVesting[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(userVesting[1].toString(), await web3.utils.toWei('0'))
+
+                time.increase(26 * 7 * 24 * 60 * 60)
+                await vesting.claim(0, { from: accounts[1] })
+                let claimed = await vesting.getVesting(accounts[1], 0)
+                assert.equal(claimed[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(claimed[1].toString(), await web3.utils.toWei('50').toString())
+            })
+
+            it('With no cliff', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 0, 156);
+                let userVesting = await vesting.getVesting(accounts[1], 0)
+                assert.equal(userVesting[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(userVesting[1].toString(), await web3.utils.toWei('0'))
+
+                time.increase(13 * 7 * 24 * 60 * 60)
+                await vesting.claim(0, { from: accounts[1] })
+                let claimed = await vesting.getVesting(accounts[1], 0)
+                assert.equal(claimed[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(claimed[1].toString().slice(0, 6), await web3.utils.toWei('4.16666').toString().slice(0, 6))
+            })
+
+            it('Allows a user to claim against multiple schedules', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('150'))
+                //Setup multiple vesting schedules
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 26);
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('100'), true, 26, 52);
+
+                time.increase(26 * 7 * 24 * 60 * 60)
+                let tokensBefore = await tcr.balanceOf(accounts[1])
+                await vesting.claim(0, { from: accounts[1] })
+                let claimed = await vesting.getVesting(accounts[1], 0)
+                assert.equal(claimed[0].toString(), await web3.utils.toWei('50'))
+                assert.equal(claimed[1].toString(), await web3.utils.toWei('50').toString())
+                await vesting.claim(1, { from: accounts[1] })
+                let claimed2 = await vesting.getVesting(accounts[1], 1)
+                assert.equal(claimed2[0].toString(), await web3.utils.toWei('100'))
+                assert.equal(claimed2[1].toString().slice(0,6), await web3.utils.toWei('50').toString().slice(0,6))
+                let tokensAfter = await tcr.balanceOf(accounts[1])
+                assert.equal(tokensAfter.sub(tokensBefore).toString().slice(0, 6), web3.utils.toWei('100').toString().slice(0, 6))
+            })
+            it('Allows the user to vest from the contract with insufficient tokens', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('100'), true, 26, 26);
+
+                time.increase(26 * 7 * 24 * 60 * 60)
+                let tokensBefore = await tcr.balanceOf(accounts[1])
+
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.claim(0, { from: accounts[1] })
+                let claimed = await vesting.getVesting(accounts[1], 0)
+                assert.equal(claimed[0].toString(), await web3.utils.toWei('100'))
+                let tokensAfter = await tcr.balanceOf(accounts[1])
+                assert.equal(tokensAfter.sub(tokensBefore).toString().slice(0, 6), web3.utils.toWei('100').toString().slice(0, 6))
+            })
+        })
+    })
+    describe('cancel', () => {
+        context('When the vesting schedule is not cancellable', () => {
+            it('rejects cancelling', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156);
+
+                await expectRevert(
+                    vesting.cancelVesting(accounts[1], 0),
+                    "Vesting: Account is fixed"
+                )
+            })
+        })
+
+        context('When the vesting schedule is called by owner', () => {
+            it('cannot cancel', async () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), false,26, 156);
+                //Increase to 1 years and claim
+                time.increase(78 * 7 * 24 * 60 * 60)
+                let balanceBefore = await tcr.balanceOf(accounts[1])
+                await vesting.claim(0, { from: accounts[1] })
+                let balanceAfter = await tcr.balanceOf(accounts[1])
+                assert.equal(balanceAfter.sub(balanceBefore).toString().slice(0, 4), web3.utils.toWei('25').toString().slice(0, 4))
+                //Attempt to cancel the vesting as the owner account
+                await vesting.cancelVesting(accounts[1], 0)
+                //Try claim at end of life --> wont throw
+                time.increase(52 * 7 * 24 * 60 * 60)
+                vesting.claim(0, { from: accounts[1] }),
+                balanceAfter = await tcr.balanceOf(accounts[1])
+            })
+        })
+        context('When the DAO is calling cancel vesting', () => {
+            it('Allows cancelling ',async  () => {
+                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), false,26, 156);
+                //Increase to 1 years and claim
+                time.increase(78 * 7 * 24 * 60 * 60)
+                let balanceBefore = await tcr.balanceOf(accounts[1])
+                await vesting.claim(0, { from: accounts[1] })
+                let balanceAfter = await tcr.balanceOf(accounts[1])
+                assert.equal(balanceAfter.sub(balanceBefore).toString().slice(0, 4), web3.utils.toWei('25').toString().slice(0, 4))
+                //call function cancel vesting with DAO address
+                await vesting.cancelVesting(accounts[1],DAO)
+                //Try claiming tokens post DAO cancellation at end of life -> will cancel
+                time.increase(52 * 7 * 24 * 60 * 60)
+                await expectRevert(
+                    vesting.claim(0, { from: accounts[1] }),
+                    "Vesting: No claimable tokens"
+                )
+            })
+        })
+        context('When the owner is calling cancel vesting', () => {
+            it('Cancelling not allowed ', async () => {
+                //call function cancel vesting with DAO address
+                await vesting.cancelVesting(accounts[1],0)
+                //Try claiming tokens post DAO cancellation
+                time.increase(52 * 7 * 24 * 60 * 60)
+                await expectRevert(
+                    vesting.claim(0, { from: accounts[1] }),
+                    "Vesting: No claimable tokens"
+                )
+            })
+        })
+    })
+
+    describe('Withdraw', () => {
+        context('When not owner', () => {
+            it('rejects', async () => {
+                await expectRevert(
+                    vesting.withdraw(web3.utils.toWei("50"), { from: accounts[1] }),
+                    "Ownable: caller is not the owner"
+                )
+            })
+        })
+
+        context('When the owner', () => {
+            it('Allows withdrawing of TCR', async () => {
+                let balanceStart = await tcr.balanceOf(accounts[0])
+                await vesting.withdraw(web3.utils.toWei("50"))
+                let balanceAfter = await tcr.balanceOf(accounts[0])
+                assert.equal(balanceAfter.sub(balanceStart), web3.utils.toWei('50'))
+            })
+
+            it('Blocks withdrawing if tokens are locked', async () => {
+                //Lock up 4999 tokens
+                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('4999'), true,26, 156);
+                await expectRevert(
+                    vesting.withdraw(web3.utils.toWei("2")),
+                    "Vesting: amount > tokens leftover"
+                )
+            })
+        })
+    })
+});

--- a/test/EmployeeVesting.js
+++ b/test/EmployeeVesting.js
@@ -31,7 +31,7 @@ contract('EmployeeVesting', (accounts) => {
 
         context('When not enough tokens are held', () => {
             it('allows vesting to be set', async () => {
-                await tcr.transfer(vesting.address, web3.utils.toWei('51'))
+                await tcr.transfer(vesting.address, web3.utils.toWei('49'))
                 await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156, now);
                 let userVesting = await vesting.getVesting(accounts[1], 0)
                 assert.equal(userVesting[0].toString(), await web3.utils.toWei('50'))
@@ -261,7 +261,7 @@ contract('EmployeeVesting', (accounts) => {
                 assert.equal(claimed[1].toString(), await web3.utils.toWei('50').toString())
             })
 
-            it('With no cliff', async () => {
+            it('works with no cliff', async () => {
                 await tcr.transfer(vesting.address, web3.utils.toWei('50'))
                 await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 0, 156, now);
                 let userVesting = await vesting.getVesting(accounts[1], 0)

--- a/test/EmployeeVesting.js
+++ b/test/EmployeeVesting.js
@@ -31,7 +31,7 @@ contract('EmployeeVesting', (accounts) => {
 
         context('When not enough tokens are held', () => {
             it('allows vesting to be set', async () => {
-                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
+                await tcr.transfer(vesting.address, web3.utils.toWei('51'))
                 await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('50'), true, 26, 156, now);
                 let userVesting = await vesting.getVesting(accounts[1], 0)
                 assert.equal(userVesting[0].toString(), await web3.utils.toWei('50'))

--- a/test/EmployeeVesting.js
+++ b/test/EmployeeVesting.js
@@ -261,20 +261,6 @@ contract('EmployeeVesting', (accounts) => {
                 let tokensAfter = await tcr.balanceOf(accounts[1])
                 assert.equal(tokensAfter.sub(tokensBefore).toString().slice(0, 6), web3.utils.toWei('100').toString().slice(0, 6))
             })
-            it('Allows the user to vest from the contract with insufficient tokens', async () => {
-                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
-                await vesting.setVestingSchedule(accounts[1], web3.utils.toWei('100'), true, 26, 26);
-
-                time.increase(26 * 7 * 24 * 60 * 60)
-                let tokensBefore = await tcr.balanceOf(accounts[1])
-
-                await tcr.transfer(vesting.address, web3.utils.toWei('50'))
-                await vesting.claim(0, { from: accounts[1] })
-                let claimed = await vesting.getVesting(accounts[1], 0)
-                assert.equal(claimed[0].toString(), await web3.utils.toWei('100'))
-                let tokensAfter = await tcr.balanceOf(accounts[1])
-                assert.equal(tokensAfter.sub(tokensBefore).toString().slice(0, 6), web3.utils.toWei('100').toString().slice(0, 6))
-            })
         })
     })
     describe('cancel', () => {
@@ -355,6 +341,25 @@ contract('EmployeeVesting', (accounts) => {
                     vesting.withdraw(web3.utils.toWei("2")),
                     "Vesting: amount > tokens leftover"
                 )
+            })
+        })
+
+        context('setDAO', async () => {
+            context('when called by owner', async() => {
+                it('succeeds', async() => {
+                    await vesting.setDAOAddress(accounts[1])
+                    let dao = await vesting.DAO()
+                    assert.equal(dao, accounts[1])
+                })
+            })
+
+            context('when called by non owner', async() => {
+                it('succeeds', async() => {
+                    await expectRevert(
+                        vesting.setDAOAddress(accounts[1], { from: accounts[1]}),
+                        "Ownable: caller is not the owner"
+                    )
+                })
             })
         })
     })

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -19,6 +19,11 @@ module.exports = {
       port: 8545,
       network_id: '*',
     },
+    EmployeeVesting: {
+      host: '127.0.0.1',
+      port: 8545,
+      network_id: '*',
+    },
     DAODEPLOY: {
       network_id: '1',
       gasPrice: 95000000000,


### PR DESCRIPTION
# Motivation
Added features for optimising the way in which employee vesting is handled. This includes only the DAO being able to cancel employee vests, adding functionality for multiple employee vesting schedules within a single transaction. 

# Changes
-Added capability for adding multiple employee vesting schedules in one transaction
-Added onlyDAO modifier
-Added setDAOAddress for changing the dao address
-Changed cancel vesting function to only be callable by DAO address