### PR TITLE
Add `allowMultisig` bool to `ProposalCreated` event

### DIFF
--- a/contracts/MultisigDAOUpgradeable.sol
+++ b/contracts/MultisigDAOUpgradeable.sol
@@ -82,7 +82,7 @@ contract TracerMultisigDAO is Initializable {
     mapping(address => Stake) public stakers;
     mapping(uint256 => Proposal) public proposals;
 
-    event ProposalCreated(uint256 proposalId);
+    event ProposalCreated(uint256 proposalId, bool allowMultisig);
     event ProposalPassed(uint256 proposalId);
     event ProposalRejected(uint256 proposalId);
     event TargetExecuted(uint256 proposalId, address target, bytes returnData);
@@ -220,7 +220,7 @@ contract TracerMultisigDAO is Initializable {
         });
         proposals[proposalCounter].stakerTokensVoted[msg.sender] = userStaked;
         emit UserVote(msg.sender, true, proposalCounter, userStaked);
-        emit ProposalCreated(proposalCounter);
+        emit ProposalCreated(proposalCounter, _allowMultisig);
         proposalCounter += 1;
     }
 


### PR DESCRIPTION
Adam Bawi said that:
- If Proposal is created with multisig, send regular alert
- If Proposal is created with multisig, send warning alert

So currently, `dao-listener` is doing just that:
<img width="665" alt="Screenshot 2021-12-01 at 13 02 16" src="https://user-images.githubusercontent.com/44982443/144239143-eaf97b92-7014-463a-abeb-75746b2e397b.png">
(screenshot is from `dao-testing` channel, these proposals aren't real)

However, there's no direct way to see if a proposal was created with (or without) multisig support.
Therefore, I had to implement extra logic in `dao-listener` to decode the passed in parameters:
<img width="764" alt="Screenshot 2021-12-01 at 13 04 29" src="https://user-images.githubusercontent.com/44982443/144239415-7ecbd8b8-c620-422e-a67b-efe72a596861.png">

If it's important to know whether a proposal was created with (or without) multisig support, I think it belongs in an event.
It will eliminate the need for all this extra logic.
This PR does just that.